### PR TITLE
[AZ] Add POSITIVE and DEATH to races

### DIFF
--- a/dataset/races/mappings.yaml
+++ b/dataset/races/mappings.yaml
@@ -7,6 +7,9 @@ AK:
   Other: POS_OTHER
   Unknown: POS_UNKNOWN
   White: POS_WHITE
+AZ:
+  SUM_Number_Confirmed: POSITIVE
+  Deaths: DEATH
 NM:
   created: TIMESTAMP
   asian: POS_ASIAN

--- a/dataset/races/urls.yaml
+++ b/dataset/races/urls.yaml
@@ -5,6 +5,15 @@ AK:
   params: {where: 1=1, outFields: '*', f: json}
   type: arcgis
   desc: Everything
+AZ:
+- url: https://services6.arcgis.com/l7uujk4hHifqabRB/ArcGIS/rest/services/COVID19_County_Level_View_Layer/FeatureServer/0/query
+  params: {where: 1=1, outStatistics: [{"statisticType": "sum", "onStatisticField": "Number_Confirmed"}], f: json}
+  type: arcgis
+  desc: Cases
+- url: https://services6.arcgis.com/l7uujk4hHifqabRB/ArcGIS/rest/services/ADHS_Count/FeatureServer/0/query
+  params: {where: 1=1, outFields: Deaths, f: json}
+  type: arcgis
+  desc: Deaths
 NM:
 - url: https://e7p503ngy5.execute-api.us-west-2.amazonaws.com/prod/GetPublicStatewideData
   params: null


### PR DESCRIPTION
Didn't realize that AZ uses Tableau for race/ethnicity data until I'd already added in positives and deaths so race/ethnicity will come after I've figured out what to do with Tableau.