### PR TITLE
changed the way zip archives were handled in states.handle_ma

### DIFF
--- a/fetcher/extras/states.py
+++ b/fetcher/extras/states.py
@@ -14,7 +14,6 @@ import re
 from fetcher.utils import map_attributes, Fields, csv_sum, extract_arcgis_attributes
 
 
-
 ''' This file contains extra handling needed for some states
 To make it work, the method must be called "handle_{state_abbreviation:lower_case}"
 The parameters are:

--- a/fetcher/extras/states.py
+++ b/fetcher/extras/states.py
@@ -12,7 +12,7 @@ import os
 import re
 
 from fetcher.utils import map_attributes, Fields, csv_sum, extract_arcgis_attributes
-from fetcher.extras.common import MaContextManager
+
 
 
 ''' This file contains extra handling needed for some states
@@ -770,6 +770,7 @@ def handle_ma(res, mapping):
                 tagged[Fields.HOSP.name] = summed[hosp_key]
 
     return tagged
+
 
 def handle_ut(res, mapping):
     tagged = {}


### PR DESCRIPTION
Hey, I was trying to get this script up and running locally and noticed that handle_ma was throwing and exception. It looks like the urllib BufferedReader returned when opening the url was being handled like it was the zip archive itself. It looks like this was just the Buffered Reader. I persisted this to the temp directory and then extracted the needed files. It looks like handle_ma is returning the extracted data now.

I also noticed that some of this functionality was moved to a context manager today. I think the fix I am submitting would work and the context manager approach is still trying to  read the urllib BufferReader with this line instead of reading a zip archive. 
`shutil.copyfileobj(response, tmpfile)`

I did not run a full end to end test on this or verify the data was being persisted and extracted correctly.

Also, this would probably make sense to be extracted to a utility class in the future in case extracting of other zip archives are needed.

Thoughts about taking this PR